### PR TITLE
Refactor scroll

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -48,7 +48,6 @@ rules:
   max-len: [2, 210, { 'ignoreUrls': true }]
   max-lines: [2, { 'max': 390, 'skipComments': true }]
   max-lines-per-function: [2, 120]
-  max-nested-callbacks: [2, 2]
   max-params: [2, 4]
   max-statements: [2, 37]
   max-statements-per-line: [2, { 'max': 1 }]
@@ -135,7 +134,6 @@ rules:
   no-unsafe-negation: 2
   no-unused-expressions: 2
   no-unused-vars: 2
-  no-use-before-define: 2
   no-useless-call: 2
   no-useless-catch: 2
   no-useless-computed-key: 2

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -128,7 +128,7 @@ class ToscScroll extends LitElement {
 
     /* enables dragabillity for scrolls */
     this.addEventListener('mousedown', (e) => {
-      const startY = e.pageY - this.offsetTop - this.scroll.offsetTop;
+      const startY = e.pageY;
       const scrollUp = this.cur;
 
       const onMouseUp = () => {
@@ -145,7 +145,7 @@ class ToscScroll extends LitElement {
       const onMouseMove = (moveEvent) => {
         moveEvent.preventDefault();
 
-        const y = moveEvent.pageY - this.offsetTop - this.scroll.offsetTop;
+        const y = moveEvent.pageY;
         const scroll = y - startY;
 
         if (Math.abs(scroll) < 10) return;

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -168,7 +168,7 @@ class ToscScroll extends LitElement {
       };
     });
 
-    this.letSize = parseInt(getComputedStyle(this).getPropertyValue('--text-size'), 10);
+    this.letterSize = parseInt(getComputedStyle(this).getPropertyValue('--text-size'), 10);
     this.bottom = this.scroll.offsetHeight / 2;
 
     this.cur = this.letterPos(this.active);
@@ -192,7 +192,7 @@ class ToscScroll extends LitElement {
       case 'red':
         return 0;
       case 'blue':
-        return 2 * this.letSize;
+        return 2 * this.letterSize;
       case 'green':
         return this.bottom;
       default:
@@ -208,7 +208,7 @@ class ToscScroll extends LitElement {
   }
 
   updateValue() {
-    const newVal = ['red', 'blue', 'green'][this.getLetId(this.cur)];
+    const newVal = ['red', 'blue', 'green'][this.getLetterId(this.cur)];
     if (newVal === this.active) return;
     this.active = newVal;
 
@@ -221,10 +221,10 @@ class ToscScroll extends LitElement {
   }
 
   //because !
-  getLetId(pos) {
-    const { letSize } = this;
-    if (pos < letSize * 0.5) return 0; // half of the first letter
-    if (pos < letSize * 3) return 1; // half of the second letter + spacing
+  getLetterId(pos) {
+    const { letterSize } = this;
+    if (pos < letterSize * 0.5) return 0; // half of the first letter
+    if (pos < letterSize * 3) return 1; // half of the second letter + spacing
     return 2;
   }
 
@@ -242,8 +242,8 @@ class ToscScroll extends LitElement {
   stabilize() {
     clearTimeout(this.stabletm);
     this.stabletm = setTimeout(() => {
-      const letId = this.getLetId(this.cur); //yep it is junky!
-      const stablePos = this.letterPos(['red', 'blue', 'green'][letId]);
+      const letterId = this.getLetterId(this.cur); //yep it is junky!
+      const stablePos = this.letterPos(['red', 'blue', 'green'][letterId]);
       this.updateScroll(stablePos);
       this.updateValue();
     }, 600);

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -168,13 +168,8 @@ class ToscScroll extends LitElement {
       };
     });
 
-    /* enables dragabillity for scrolls */
-
     this.letSize = parseInt(getComputedStyle(this).getPropertyValue('--text-size'), 10);
-    //5 cuz 3 from each letter and extra 2 from margin. And 3 cuz ther is 3 letters
-    this.blockSize = this.letSize * (5 / 3);
     this.bottom = this.scroll.offsetHeight / 2;
-    this.top = 0;
 
     this.cur = this.letterPos(this.active);
     this.updateScroll(this.cur);

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -1,5 +1,4 @@
 import { LitElement, css, html } from 'lit-element';
-import { clamp } from './clamp.js';
 
 class ToscScroll extends LitElement {
   static get styles() {
@@ -129,7 +128,7 @@ class ToscScroll extends LitElement {
     /* enables dragabillity for scrolls */
     this.addEventListener('mousedown', (e) => {
       const startY = e.pageY;
-      const scrollUp = this.cur;
+      const startScroll = this.cur;
 
       const onMouseUp = () => {
         removeListeners();
@@ -145,20 +144,15 @@ class ToscScroll extends LitElement {
       const onMouseMove = (moveEvent) => {
         moveEvent.preventDefault();
 
-        const y = moveEvent.pageY;
-        const scroll = y - startY;
+        const scroll = moveEvent.pageY - startY;
 
         if (Math.abs(scroll) < 10) return;
         this.block = true;
 
-        const pos = clamp(scrollUp - scroll, this.top, this.bottom);
+        const pos = startScroll - scroll;
         this.updateScroll(pos);
 
-        const letId = this.getLetId(pos);
-        if (letId !== this.curLetId) {
-          this.curLetId = letId;
-          this.updateValue();
-        }
+        this.updateValue();
 
         this.stabilize();
       };

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -114,6 +114,7 @@ class ToscScroll extends LitElement {
   constructor() {
     super();
     this.cur = 0;
+    this.scrolling = this.scrolling.bind(this);
   }
 
   firstUpdated() {
@@ -123,9 +124,7 @@ class ToscScroll extends LitElement {
 
     this.scroll = this.shadowRoot.querySelector('#scroll');
 
-    this.addEventListener('touchmove', this.scrolling);
-
-    this.addEventListener('wheel', this.scrolling);
+    this.scroll.addEventListener('scroll', this.scrolling);
 
     /* enables dragabillity for scrolls */
     this.addEventListener('mousedown', (e) => {
@@ -164,7 +163,7 @@ class ToscScroll extends LitElement {
         this.updateValue();
       }
 
-      this.stableLetter(pos);
+      this.stabilize();
     });
 
     /* enables dragabillity for scrolls */
@@ -212,7 +211,7 @@ class ToscScroll extends LitElement {
   }
 
   updateValue() {
-    const newVal = ['red', 'blue', 'green'][this.getLetId(this.cur, 0)];
+    const newVal = ['red', 'blue', 'green'][this.getLetId(this.cur)];
     if (newVal === this.active) return;
     this.active = newVal;
 
@@ -226,9 +225,9 @@ class ToscScroll extends LitElement {
 
   //because !
   getLetId(pos) {
-    const blockSize = (this.letSize * 5) / 3;
-    if (pos < blockSize) return 0;
-    else if (pos < 2 * blockSize) return 1;
+    const { letSize } = this;
+    if (pos < letSize * 0.5) return 0; // half of the first letter
+    if (pos < letSize * 3) return 1; // half of the second letter + spacing
     return 2;
   }
 
@@ -240,19 +239,17 @@ class ToscScroll extends LitElement {
   scrolling() {
     this.cur = this.scroll.scrollTop;
     this.updateValue();
-    this.stableLetter(this.cur);
+    this.stabilize();
   }
 
-  stableLetter(pos) {
+  stabilize() {
     clearTimeout(this.stabletm);
-    this.stabletm = setTimeout(() => this.stabilize(pos, 0), 600);
-  }
-
-  stabilize(pos, direction) {
-    const letId = this.getLetId(pos, direction); //yep it is junky!
-    const stablePos = this.letterPos(['red', 'blue', 'green'][letId]);
-    this.updateScroll(stablePos);
-    this.updateValue();
+    this.stabletm = setTimeout(() => {
+      const letId = this.getLetId(this.cur); //yep it is junky!
+      const stablePos = this.letterPos(['red', 'blue', 'green'][letId]);
+      this.updateScroll(stablePos);
+      this.updateValue();
+    }, 600);
   }
 }
 

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -128,8 +128,8 @@ class ToscScroll extends LitElement {
 
     /* enables dragabillity for scrolls */
     this.addEventListener('mousedown', (e) => {
-      this.startY = e.pageY - this.offsetTop - this.scroll.offsetTop;
-      this.scrollUp = this.cur;
+      const startY = e.pageY - this.offsetTop - this.scroll.offsetTop;
+      const scrollUp = this.cur;
 
       const onMouseUp = () => {
         removeListeners();
@@ -146,12 +146,12 @@ class ToscScroll extends LitElement {
         moveEvent.preventDefault();
 
         const y = moveEvent.pageY - this.offsetTop - this.scroll.offsetTop;
-        const scroll = y - this.startY;
+        const scroll = y - startY;
 
         if (Math.abs(scroll) < 10) return;
         this.block = true;
 
-        const pos = clamp(this.scrollUp - scroll, this.top, this.bottom);
+        const pos = clamp(scrollUp - scroll, this.top, this.bottom);
         this.updateScroll(pos);
 
         const letId = this.getLetId(pos);

--- a/src/js/tosc-scroll.js
+++ b/src/js/tosc-scroll.js
@@ -128,42 +128,50 @@ class ToscScroll extends LitElement {
 
     /* enables dragabillity for scrolls */
     this.addEventListener('mousedown', (e) => {
-      this.isMDown = true;
       this.startY = e.pageY - this.offsetTop - this.scroll.offsetTop;
       this.scrollUp = this.cur;
-    });
 
-    this.addEventListener('mouseup', () => {
-      this.isMDown = false;
-      //delya cuz click is happaning a bit later
-      setTimeout(() => (this.block = false), 100);
-    });
+      const onMouseUp = () => {
+        removeListeners();
+        //delya cuz click is happaning a bit later
+        setTimeout(() => (this.block = false), 100);
+      };
 
-    this.addEventListener('mouseleave', () => {
-      this.isMDown = false;
-      this.block = false;
-    });
+      const onMouseLeave = () => {
+        removeListeners();
+        this.block = false;
+      };
 
-    this.addEventListener('mousemove', (e) => {
-      if (!this.isMDown) return;
-      e.preventDefault();
+      const onMouseMove = (moveEvent) => {
+        moveEvent.preventDefault();
 
-      const y = e.pageY - this.offsetTop - this.scroll.offsetTop;
-      const scroll = y - this.startY;
+        const y = moveEvent.pageY - this.offsetTop - this.scroll.offsetTop;
+        const scroll = y - this.startY;
 
-      if (Math.abs(scroll) < 10) return;
-      this.block = true;
+        if (Math.abs(scroll) < 10) return;
+        this.block = true;
 
-      const pos = clamp(this.scrollUp - scroll, this.top, this.bottom);
-      this.updateScroll(pos);
+        const pos = clamp(this.scrollUp - scroll, this.top, this.bottom);
+        this.updateScroll(pos);
 
-      const letId = this.getLetId(pos);
-      if (letId !== this.curLetId) {
-        this.curLetId = letId;
-        this.updateValue();
-      }
+        const letId = this.getLetId(pos);
+        if (letId !== this.curLetId) {
+          this.curLetId = letId;
+          this.updateValue();
+        }
 
-      this.stabilize();
+        this.stabilize();
+      };
+
+      this.addEventListener('mousemove', onMouseMove);
+      this.addEventListener('mouseup', onMouseUp);
+      this.addEventListener('mouseleave', onMouseLeave);
+
+      const removeListeners = () => {
+        this.removeEventListener('mousemove', onMouseMove);
+        this.removeEventListener('mouseup', onMouseUp);
+        this.removeEventListener('mouseleave', onMouseLeave);
+      };
     });
 
     /* enables dragabillity for scrolls */


### PR DESCRIPTION
d393361  - использует такой приём: обработчик `mousemove` навешивается ТОЛЬКО после `mousedown` и убирается сразу после `mouseup`. Это позволяет убрать много лишних вызовов =)

4e6c70c - заменяет переменные в `this` на локальные константы. Советую как можно меньше присваивать в `this`, потому что так переменные становятся доступны по всему классу, что заставляет думать, что они используются где-то ещё, что усложняет внесение изменений в код.

0d38f7b - убирает лишние слагаемые, которые в разнице дают 0